### PR TITLE
Update sphinx autoapi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ pytest = "^7.4.0"
 pytest-cov = "^4.1.0"
 requests = "^2.31.0"
 jupyter = "^1.0.0"
-myst-nb = "^0.17.2"
+myst-nb = "^1.0.0rc0"
 sphinx-autoapi = "^3.0.0"
 sphinx-rtd-theme = "^1.2.2"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ pytest-cov = "^4.1.0"
 requests = "^2.31.0"
 jupyter = "^1.0.0"
 myst-nb = "^0.17.2"
-sphinx-autoapi = "^2.1.1"
+sphinx-autoapi = "^3.0.0"
 sphinx-rtd-theme = "^1.2.2"
 
 [build-system]


### PR DESCRIPTION
Old autoapi no longer works in CI.

The new sphinx autoapi 3.0.0 is incompatible with myst-nb 0.17.2. Once myst-nb dependency has been updated ([issue](https://github.com/executablebooks/MyST-NB/issues/543)), we can update here as well