### PR TITLE
Fix tests for matplotlib v3.10

### DIFF
--- a/tests/test_pyvlasiator.py
+++ b/tests/test_pyvlasiator.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 from pyvlasiator.vlsv import Vlsv
 import pyvlasiator.plot
-import matplotlib
+import matplotlib as mpl
 import packaging.version
 
 filedir = os.path.dirname(__file__)
@@ -101,8 +101,8 @@ class TestVlsv:
 class TestPlot:
     dir = "tests/data/"
     files = (dir + "bulk.1d.vlsv", dir + "bulk.2d.vlsv", dir + "bulk.amr.vlsv")
-    matplotlib.use("Agg")
-    version_str = matplotlib.__version__
+    mpl.use("Agg")
+    version_str = mpl.__version__
     version = packaging.version.parse(version_str)
 
     def test_1d_plot(self):
@@ -115,49 +115,31 @@ class TestPlot:
     def test_2d_plot(self):
         meta = Vlsv(self.files[1])
         v = meta.pcolormesh("proton/vg_rho").get_array()
-        if self.version.major == 3 and self.version.minor == 9:
-            assert v[99, 60] == pytest.approx(999535.8) and v.data.size == 6300
-        else:
-            assert v[-3] == pytest.approx(999535.8) and v.data.size == 6300
+        assert v[99, 60] == pytest.approx(999535.8) and v.data.size == 6300
         v = meta.contour("proton/vg_rho").get_array()
         assert v[-3] == 4000000.0
         v = meta.contourf("proton/vg_rho").get_array()
-        if self.version.major == 3 and self.version.minor == 9:
-            assert v[-3] == 3600000.0
-        else:
-            assert v[-3] == 4000000.0
+        assert v[-3] == 3600000.0
         v = meta.pcolormesh("vg_b_vol").get_array()
-        if self.version.major == 3 and self.version.minor == 9:
-            assert v[0, 1] == pytest.approx(3.0045673e-09)
-        else:
-            assert v[2] == pytest.approx(3.0045673e-09)
+        assert v[0, 1] == pytest.approx(3.0051286e-09)
         v = meta.pcolormesh("fg_b", comp=0).get_array()
-        if self.version.major == 3 and self.version.minor == 9:
-            assert v[99, 60] == pytest.approx(-2.999047e-09) and v.data.size == 6300
-        else:
-            assert v[-3] == pytest.approx(-2.999047e-09) and v.data.size == 6300
+        assert v[99, 60] == pytest.approx(-2.999047e-09) and v.data.size == 6300
 
     def test_3d_amr_slice(self):
         meta = Vlsv(self.files[2])
         v = meta.pcolormesh("proton/vg_rho").get_array()
-        if matplotlib.__version__ < "3.8":
-            assert v[254] == pytest.approx(1.0483886e6) and len(v) == 512
-        else:
-            assert v[15, 31] == pytest.approx(1.0483886e6) and v.data.size == 512
+        assert v[15, 31] == pytest.approx(1.0483886e6) and v.data.size == 512
 
     def test_stream_plot(self):
         meta = Vlsv(self.files[1])
         p = meta.streamplot("proton/vg_v", comp="xy")
-        assert type(p) == matplotlib.streamplot.StreamplotSet
+        assert type(p) == mpl.streamplot.StreamplotSet
 
     def test_vdf_plot(self):
         meta = Vlsv(self.files[0])
         loc = [2.0, 0.0, 0.0]
         v = meta.vdfslice(loc, verbose=True).get_array()
-        if matplotlib.__version__ < "3.8":
-            assert v[785] == 238.24398578141802
-        else:
-            assert v[19, 25] == 238.24398578141802
+        assert v[19, 25] == 238.24398578141802
 
 
 def load(files):


### PR DESCRIPTION
Remove branching for matplotlib version before and after 3.8. Current stable version is 3.10