### PR TITLE
Fix: Use density for inner boundary filling

### DIFF
--- a/src/pyvlasiator/plot/plot.py
+++ b/src/pyvlasiator/plot/plot.py
@@ -369,11 +369,12 @@ def _plot2d(
     else:
         pArgs = set_args(meta, var, axisunit)
         data = prep2d(meta, var, comp)
+        normal = -1
 
     x1, x2 = get_axis(pArgs.axisunit, pArgs.plotrange, pArgs.sizes)
 
     if var in ("fg_b", "fg_e", "vg_b_vol", "vg_e_vol") or var.endswith("vg_v"):
-        _fillinnerBC(data)
+        _fillinnerBC(data, meta, var, pArgs, normal)
 
     norm, ticks = set_colorbar(colorscale, vmin, vmax, data)
 
@@ -797,11 +798,25 @@ def get_axis(axisunit: AxisUnit, plotrange: tuple, sizes: tuple) -> tuple:
     return x, y
 
 
-def _fillinnerBC(data: np.ndarray):
+def _fillinnerBC(data: np.ndarray, meta: Vlsv, var: str, pArgs: PlotArgs, normal: int):
     """
-    Fill sparsity/inner boundary cells with NaN.
+    Fill sparsity/inner boundary cells with NaN using density as a mask.
     """
-    data[data == 0] = np.nan
+    if "/" in var:
+        species = var.split("/")[0]
+        rho_var = f"{species}/vg_rho"
+    else:
+        # Default to proton density for field quantities
+        rho_var = "proton/vg_rho"
+
+    if meta.has_variable(rho_var):
+        if normal != -1:
+            rho_data = prep2dslice(meta, rho_var, normal, -1, pArgs)
+        else:
+            rho_data = prep2d(meta, rho_var, -1)
+        data[rho_data == 0] = np.nan
+    else:
+        data[data == 0] = np.nan
 
 
 def set_colorbar(

--- a/src/pyvlasiator/plot/plot.py
+++ b/src/pyvlasiator/plot/plot.py
@@ -809,14 +809,15 @@ def _fillinnerBC(data: np.ndarray, meta: Vlsv, var: str, pArgs: PlotArgs, normal
         # Default to proton density for field quantities
         rho_var = "proton/vg_rho"
 
-    if meta.has_variable(rho_var):
-        if normal != -1:
-            rho_data = prep2dslice(meta, rho_var, normal, -1, pArgs)
-        else:
-            rho_data = prep2d(meta, rho_var, -1)
-        data[rho_data == 0] = np.nan
-    else:
+    if not meta.has_variable(rho_var):
         data[data == 0] = np.nan
+        return
+
+    if normal != -1:
+        rho_data = prep2dslice(meta, rho_var, normal, -1, pArgs)
+    else:
+        rho_data = prep2d(meta, rho_var, -1)
+    data[rho_data == 0] = np.nan
 
 
 def set_colorbar(


### PR DESCRIPTION
The `_fillinnerBC` function now uses the density to fill the inner boundary instead of the variable itself. This is a more robust way to handle the inner boundary, as the density is a better indicator of the plasma presence.

The function signature has been updated to accept the necessary metadata to fetch the density data. The call to this function in `_plot2d` has been updated accordingly.